### PR TITLE
Adding the option to use smallcaps instead of strict uppercase in headings

### DIFF
--- a/cv.typ
+++ b/cv.typ
@@ -8,6 +8,7 @@
 //#let bodyfont = "Linux Libertine"   // Set font for body
 //#let fontsize = 10pt // 10pt, 11pt, 12pt
 //#let linespacing = 6pt
+//#let headingsmallcaps = false
 
 //#let showAddress = true // true/false Show address in contact info
 //#let showNumber = true  // true/false Show phone number in contact info
@@ -49,7 +50,7 @@
     ): it => block(width: 100%)[
         #set align(left)
         #set text(font: uservars.headingfont, size: 1em, weight: "bold")
-        #upper(it.body)
+        #if(uservars.headingsmallcaps) {smallcaps(it.body)} else {upper(it.body)}
         #v(-0.75em) #line(length: 100%, stroke: 1pt + black) // Draw a line
     ]
 
@@ -58,7 +59,7 @@
         level: 1,
     ): it => block(width: 100%)[
         #set text(font: uservars.headingfont, size: 1.5em, weight: "bold")
-        #upper(it.body)
+        #if(uservars.headingsmallcaps) {smallcaps(it.body)} else {upper(it.body)}
         #v(2pt)
     ]
 

--- a/cv.typ
+++ b/cv.typ
@@ -50,7 +50,11 @@
     ): it => block(width: 100%)[
         #set align(left)
         #set text(font: uservars.headingfont, size: 1em, weight: "bold")
-        #if(uservars.headingsmallcaps) {smallcaps(it.body)} else {upper(it.body)}
+        #if (uservars.at("headingsmallcaps", default:false)) {
+            smallcaps(it.body)
+        } else {
+            upper(it.body)
+        }
         #v(-0.75em) #line(length: 100%, stroke: 1pt + black) // Draw a line
     ]
 
@@ -59,7 +63,11 @@
         level: 1,
     ): it => block(width: 100%)[
         #set text(font: uservars.headingfont, size: 1.5em, weight: "bold")
-        #if(uservars.headingsmallcaps) {smallcaps(it.body)} else {upper(it.body)}
+        #if (uservars.at("headingsmallcaps", default:false)) {
+            smallcaps(it.body)
+        } else {
+            upper(it.body)
+        }
         #v(2pt)
     ]
 

--- a/example.typ
+++ b/example.typ
@@ -10,6 +10,7 @@
     linespacing: 6pt,
     showAddress: true, // true/false Show address in contact info
     showNumber: true,  // true/false Show phone number in contact info
+    headingsmallcaps: false
 )
 
 // setrules and showrules can be overridden by re-declaring it here


### PR DESCRIPTION
Hi, I did a small change for myself to be able to use smallcaps for headings, so I thought I might as well share the change. I also made it backwards compatible to not break anything. No pressure in merging it, I mostly just wanted to share it!