### PR TITLE
chore: update .gitignore to ignore compiled PDFs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-# cv.pdf
+# Ignore compiled PDFs
+*.pdf


### PR DESCRIPTION
Is there a reason to not ignore compiled PDFs?