### PR TITLE
added credential id key for certificates

### DIFF
--- a/cv.typ
+++ b/cv.typ
@@ -265,7 +265,7 @@
                 #if cert.url != none [
                     *#link(cert.url)[#cert.name]* \
                 ] else [
-                    *#cert.name* \
+                    *#cert.name* #h(1fr)ID: #cert.id\
                 ]
                 // line 2: issuer and date
                 Issued by #text(style: "italic")[#cert.issuer]  #h(1fr) #date \

--- a/cv.typ
+++ b/cv.typ
@@ -263,10 +263,14 @@
             block(width: 100%, breakable: isbreakable)[
                 // line 1: certificate name
                 #if cert.url != none [
-                    *#link(cert.url)[#cert.name]* #h(1fr) ID: #cert.id \
+                    *#link(cert.url)[#cert.name]* #h(1fr)
                 ] else [
-                    *#cert.name* #h(1fr)ID: #cert.id\
+                    *#cert.name* #h(1fr)
                 ]
+                #if cert.id != none [
+                    ID: #cert.id
+                ]
+                \
                 // line 2: issuer and date
                 Issued by #text(style: "italic")[#cert.issuer]  #h(1fr) #date \
             ]

--- a/cv.typ
+++ b/cv.typ
@@ -263,7 +263,7 @@
             block(width: 100%, breakable: isbreakable)[
                 // line 1: certificate name
                 #if cert.url != none [
-                    *#link(cert.url)[#cert.name]* \
+                    *#link(cert.url)[#cert.name]* #h(1fr) ID: #cert.id \
                 ] else [
                     *#cert.name* #h(1fr)ID: #cert.id\
                 ]

--- a/cv.typ.schema.json
+++ b/cv.typ.schema.json
@@ -364,6 +364,10 @@
             "type": "string",
             "format": "uri",
             "default": ""
+          },
+          "id": {
+            "type": "string",
+            "default": ""
           }
         }
       }


### PR DESCRIPTION
Allows the user to have an optional credential id right side of the certificate name.

I added this right after `#cert.name`

```typ
#h(1fr)ID: #cert.id
```
![image](https://github.com/jskherman/cv.typ/assets/19298806/c3644d61-4f12-460f-b641-d9fed6a23751)

I would have used the word "Credential ID" but some ids are 40 characters long thus I used "ID" instead.